### PR TITLE
Fix build under VS 2022

### DIFF
--- a/SMTC.vcxproj
+++ b/SMTC.vcxproj
@@ -112,6 +112,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -131,6 +131,7 @@ int ClearAll() {
     auto updater = smtc.DisplayUpdater();
     updater.ClearAll();
     updater.Update();
+    return 0;
 }
 
 __declspec(dllexport)


### PR DESCRIPTION
C++20 is required for the `<format>` header, and `ClearAll` must have a return statement to avoid UB.